### PR TITLE
Auto scroll on msg table

### DIFF
--- a/src/ui/renderer/hooks.ts
+++ b/src/ui/renderer/hooks.ts
@@ -28,6 +28,8 @@ const NO_MSG_SELECTED = -1;
 
 export function useRenderer() {
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const lastRowRef = useRef<HTMLTableRowElement>(null);
+  const autoScrollingRef = useRef(true);
   const [logData, setLogData] = useState<IpcLogData[]>([]);
   const [panelPosition, setPanelPosition] = useState<PanelPosition>('right');
   const [panelWidth, setPanelWidth] = useState(300);
@@ -53,6 +55,26 @@ export function useRenderer() {
     height: panelHeight,
   });
 
+  const updateAutoScrollState = useCallback(() => {
+    const container = tableContainerRef.current;
+
+    // if the panel is open (looking the details of a message) or the newest
+    // messages needs to appear on top, there's no need to scroll
+    if (isPanelOpen || scrollBy[1] || !container) {
+      autoScrollingRef.current = false;
+      return;
+    }
+
+    // otherwise, the autoscroll enabled when the table is scrolled up to
+    // the bottom
+    autoScrollingRef.current =
+      container.scrollTop + container.getBoundingClientRect().height >=
+      container.children[0].clientHeight;
+  }, [isPanelOpen, scrollBy, tableContainerRef.current]);
+
+  /*
+   * Set the listener on IPC messages to add new incoming data from the main process
+   */
   useEffect(() => {
     const listener = (data: ReadonlyArray<IpcLogData>): void => {
       setLogData([...data]);
@@ -60,10 +82,20 @@ export function useRenderer() {
     api.onUpdate(listener);
   }, []);
 
+  /*
+   * Auto-update the state of the DataPanel based on the selected row
+   */
   useEffect(() => {
-    setPanelOpen(logData[selectedMsgIndex] !== undefined);
+    const isOpen = logData[selectedMsgIndex] !== undefined;
+    updateAutoScrollState();
+    setPanelOpen(isOpen);
   }, [selectedMsgIndex]);
 
+  useEffect(updateAutoScrollState, [updateAutoScrollState]);
+
+  /*
+   * Fix/update the panel size when it's open and the window gets resized
+   */
   useEffect(() => {
     const fn = () => {
       if (!isPanelOpen) return;
@@ -73,6 +105,23 @@ export function useRenderer() {
     window.addEventListener('resize', listener);
     return () => window.removeEventListener('resize', listener);
   }, [isPanelOpen]);
+
+  /*
+   * Auto-scroll the table on new messages when the DataPanel is closed
+   */
+  useEffect(() => {}, []);
+
+  useEffect(() => {
+    // if autoscrolling is disabled, do nothing
+    if (!autoScrollingRef.current) return;
+
+    const container = tableContainerRef.current;
+    if (!container) return;
+
+    // scroll the container to its bottom
+    const containerBounds = container.getBoundingClientRect();
+    container.scrollBy(0, containerBounds.height);
+  }, [lastRowRef.current]);
 
   const closePanel = useCallback(() => {
     setPanelOpen(false);
@@ -159,7 +208,7 @@ export function useRenderer() {
       return;
     }
 
-    if (selectedMsgIndex == NO_MSG_SELECTED) return;
+    if (!isPanelOpen) return;
 
     // navigate through messages (only when the DataPanel is open)
     if (ev.code === 'Escape') {
@@ -182,6 +231,7 @@ export function useRenderer() {
   return {
     // basic data
     tableContainerRef,
+    lastRowRef,
     startTime: api.startTime,
     logData,
     // calculated data
@@ -199,6 +249,7 @@ export function useRenderer() {
     // callbacks
     onDragStart,
     onDrag,
+    onMainScroll: updateAutoScrollState,
     closePanel,
     setPanelPosition,
     setSelectedIpcMsg,

--- a/src/ui/renderer/hooks.ts
+++ b/src/ui/renderer/hooks.ts
@@ -208,6 +208,16 @@ export function useRenderer() {
       return;
     }
 
+    // There's no need to have a previously selected row to be able to navigate
+    // to the first or last one
+    if (ev.code === 'Home') {
+      setSelectedMsgIndex(0);
+      return;
+    } else if (ev.code === 'End') {
+      setSelectedMsgIndex(logData.length - 1);
+      return;
+    }
+
     if (!isPanelOpen) return;
 
     // navigate through messages (only when the DataPanel is open)
@@ -221,10 +231,6 @@ export function useRenderer() {
       setSelectedMsgIndex((n) => Math.max(0, n - 10));
     } else if (ev.code === 'PageDown') {
       setSelectedMsgIndex((n) => Math.min(logData.length - 1, n + 10));
-    } else if (ev.code === 'Home') {
-      setSelectedMsgIndex(0);
-    } else if (ev.code === 'End') {
-      setSelectedMsgIndex(logData.length - 1);
     }
   };
 

--- a/src/ui/renderer/index.tsx
+++ b/src/ui/renderer/index.tsx
@@ -15,6 +15,7 @@ import styles from './renderer.module.scss';
 export const Renderer: FC = () => {
   const {
     tableContainerRef,
+    lastRowRef,
     logData,
     panelPosition,
     panelWidth,
@@ -28,6 +29,7 @@ export const Renderer: FC = () => {
     isFilterInverted,
     onDragStart,
     onDrag,
+    onMainScroll,
     closePanel,
     setPanelPosition,
     setSelectedIpcMsg,
@@ -62,9 +64,14 @@ export const Renderer: FC = () => {
           clearMessages={clearMessages}
         />
       </div>
-      <div ref={tableContainerRef} className={styles.main}>
+      <div
+        ref={tableContainerRef}
+        className={styles.main}
+        onScroll={onMainScroll}
+      >
         <IpcTable
           containerRef={tableContainerRef}
+          lastRowRef={lastRowRef}
           data={logData}
           selectedMsg={selectedMsg}
           relativeTimes={displayRelativeTimes}

--- a/src/ui/table/hooks.ts
+++ b/src/ui/table/hooks.ts
@@ -5,6 +5,7 @@ import { SortableField } from '../types';
 
 export function useIpcTable({
   containerRef,
+  lastRowRef,
   data,
   selectedMsg,
   sortBy,
@@ -58,7 +59,10 @@ export function useIpcTable({
      * on keyboard shortcuts) and move the scroll to show the row, as it would
      * have happened with native scrolls
      */
-    const row = activeRowRef.current;
+    const isLastSelected = selectedMsg === data[data.length - 1];
+    // only 1 ref is passed to the row and `lastRowRef` has precedence over
+    // `activeRowRef`, so this check is needed
+    const row = (isLastSelected ? lastRowRef : activeRowRef).current;
     const container = containerRef.current;
     if (!row || !container) return;
     const containerBounds = container.getBoundingClientRect();
@@ -81,6 +85,7 @@ export function useIpcTable({
 
   return {
     rows,
+    lastRowRef,
     activeRowRef,
     selectedMsg,
     relativeTimes,

--- a/src/ui/table/index.tsx
+++ b/src/ui/table/index.tsx
@@ -11,6 +11,8 @@ import styles from './table.module.scss';
 export type Props = {
   /** Table container: needed to modify its scroll position */
   containerRef: React.MutableRefObject<HTMLDivElement>;
+  /** Needed to auto-scroll */
+  lastRowRef: React.MutableRefObject<HTMLTableRowElement>;
   data: ReadonlyArray<IpcLogData>;
   selectedMsg: IpcLogData | undefined;
   sortBy: SortableField;
@@ -29,6 +31,7 @@ export type Props = {
 export const IpcTable: FC<Props> = ({ className, ...props }) => {
   const {
     rows,
+    lastRowRef,
     activeRowRef,
     selectedMsg,
     relativeTimes,
@@ -101,7 +104,13 @@ export const IpcTable: FC<Props> = ({ className, ...props }) => {
             odd={i % 2 !== 0}
             data={row}
             active={selectedMsg === row}
-            ref={selectedMsg === row ? activeRowRef : undefined}
+            ref={
+              i === rows.length - 1
+                ? lastRowRef
+                : selectedMsg === row
+                  ? activeRowRef
+                  : undefined
+            }
             relativeTimes={relativeTimes}
             onClick={onRowClick}
           />


### PR DESCRIPTION
When receiving new messages from the IPC, the table scrolls automatically when
- a msg is not opened in the DataPanel
- the scroll is already at the bottom (to avoid scrolling when something was being checked upwards)
- the sorting is "latest at the bottom"